### PR TITLE
Fixed post-processing for scene excepted shows.

### DIFF
--- a/sickbeard/helpers.py
+++ b/sickbeard/helpers.py
@@ -543,32 +543,45 @@ def parse_result_wrapper(show,toParse,tvdbActiveLookUp=False):
         raise InvalidNameException("Unable to parse "+toParse)
     return parse_result
 
-def get_tvdbid(name, useTvdb=False):
-    logger.log(u"Trying to get the tvdbid for "+str(name), logger.DEBUG)
-            
-    for show in sickbeard.showList:
-        nameFromList = re.sub('[. -]', ' ', sanitizeSceneName(show.name)).lower().lstrip()
-        nameInQuestion = re.sub('[. -]', ' ', sanitizeSceneName(name)).lower().lstrip()
-        
+
+def _check_against_names(name, show):
+    nameInQuestion = re.sub('[. -]', ' ', sanitizeSceneName(name)).lower().lstrip()
+
+    showNames = [show.name]
+    showNames.extend(sickbeard.scene_exceptions.get_scene_exceptions(show.tvdbid))
+
+    for showName in showNames:
+        nameFromList = re.sub('[. -]', ' ', sanitizeSceneName(showName)).lower().lstrip()
+
         #nameFromList = sanitizeSceneName(show.name)
         #nameInQuestion = sanitizeSceneName(name)
-        
         # FIXME: this is ok for most shows but will give fals positives on:
         """nameFromList = "show name: special version"
            nameInQuestion = "show name"
            ->will match
-           
+
            but the otherway around:
-           
+
            nameFromList = "show name"
            nameInQuestion = "show name: special version"
            ->will not work
-           
+
            athough the first example will only occur during pp
            and the second example is good that it wont match
-           
+
         """
+
         if nameFromList.find(nameInQuestion) == 0:
+            return True
+
+    return False
+
+
+def get_tvdbid(name, useTvdb=False):
+    logger.log(u"Trying to get the tvdbid for "+str(name), logger.DEBUG)
+            
+    for show in sickbeard.showList:
+        if _check_against_names(name, show):
             logger.log(u"Matched "+str(name)+" in the showlist to the show "+str(show.name), logger.DEBUG)
             return show.tvdbid
 


### PR DESCRIPTION
Fixed post-processing filename parsing to also check parsed show.name against scene exceptions, so that post-processing of episodes for anime shows with scene exceptions works.

I've tested this with my Ao no Exorcist episodes. :)
