### PR TITLE
Fixed searching anime episodes on fanzub (try non-scenified name).

### DIFF
--- a/sickbeard/providers/fanzub.py
+++ b/sickbeard/providers/fanzub.py
@@ -54,10 +54,14 @@ class Fanzub(generic.NZBProvider):
 		return True
 
 	def _get_season_search_strings(self, show, season):
-		return show_name_helpers.makeSceneSeasonSearchString(show, season)
+		names = [show.name.encode('utf-8')]
+		names.extend(show_name_helpers.makeSceneSeasonSearchString(show, season))
+		return names
 
 	def _get_episode_search_strings(self, ep_obj):
-		return show_name_helpers.makeSceneSearchString(ep_obj)
+		names = [(ep_obj.show.name + " " + str(ep_obj.absolute_number)).encode('utf-8')]
+		names.extend(show_name_helpers.makeSceneSearchString(ep_obj))
+		return names
 
 	def _doSearch(self, search_string, show=None):
 		if show and not show.is_anime:

--- a/sickbeard/tvcache.py
+++ b/sickbeard/tvcache.py
@@ -193,6 +193,7 @@ class TVCache():
         myDB = self._getDB()
 
         parse_result = None
+        tvdb_lang = None
         
         # if we don't have complete info then parse the filename to get it
         for curName in [name] + extraNames:


### PR DESCRIPTION
Fixed searching anime episodes on fanzub (try non-scenified name), and fix minor search bug.

It seems when I switched over to the generic helper function for getting the names of a show (which includes the scene exceptions), the name gets processed into a "scenified" form. I've added the original raw name of the show to the front of the list, it should fix up some searches. (It was breaking for a show I have on my list which has a ' in the name, stripping the character causes no results to show from fanzub)

I was also getting an unrelated not very serious error about tvdb_lang being undefined in one part of the code, so I fixed that too.
