### PR TITLE
Fixed split Show List UI

### DIFF
--- a/data/css/style.css
+++ b/data/css/style.css
@@ -1033,6 +1033,9 @@ h1.title {
   text-rendering: optimizeLegibility;
   border-bottom: 1px solid #888;
 }
+h1.anime {
+  padding-top: 13px;
+}
 .h2footer {
   margin: -45px 5px 8px 0;
   line-height: 18px;

--- a/data/interfaces/default/home.tmpl
+++ b/data/interfaces/default/home.tmpl
@@ -112,7 +112,7 @@
 #set $curListType = $curShowlist[0]
 #set $myShowList = $list($curShowlist[1])
 #if $curListType == "Anime":
-<h1>Anime List</h1>
+<h1 class="title anime">Anime List</h1>
 #end if
 <table id="showListTable$curListType" class="sickbeardTable tablesorter" cellspacing="1" border="0" cellpadding="0">
 


### PR DESCRIPTION
In the latest version of the anime development branch, there is an inconsistency in the headers' styles if you use a split list for regular and anime shows. I have repaired that bug in this pull request.
