### PR TITLE
Fixed scene exceptions tooltip

### DIFF
--- a/data/interfaces/default/displayShow.tmpl
+++ b/data/interfaces/default/displayShow.tmpl
@@ -47,7 +47,7 @@
 <script type="text/javascript" src="$sbRoot/js/plotTooltip.js?$sbPID"></script>
 <script type="text/javascript" src="$sbRoot/js/ajaxEpSearch.js?$sbPID"></script>
 
-<script type="text/javascript" src="$sbRoot/js/sceneExceptionsTooltip.js$sbPID"></script>
+<script type="text/javascript" src="$sbRoot/js/sceneExceptionsTooltip.js?$sbPID"></script>
 <div class="align-left"><b>Change Show:</b>
 <div class="navShow"><img id="prevShow" width="16" height="18" src="$sbRoot/images/prev.gif" alt="&lt;&lt;" title="Prev Show" /></div>
 <select id="pickShow">


### PR DESCRIPTION
There was a typo in `displayShow.tmpl` that caused the scene exceptions tooltip not to appear on mouseover. This pull request fixes #6.
