### PR TITLE
Corrected Growl image

### DIFF
--- a/sickbeard/notifiers/growl.py
+++ b/sickbeard/notifiers/growl.py
@@ -58,7 +58,7 @@ class GrowlNotifier:
         if options['priority']:
             notice.add_header('Notification-Priority',options['priority'])
         if options['icon']:
-            notice.add_header('Notification-Icon', 'https://raw.github.com/midgetspy/Sick-Beard/master/data/images/sickbeard.png')
+            notice.add_header('Notification-Icon', 'http://www.sickbeard.com/xbmc-notify.png')
     
         if message:
             notice.add_header('Notification-Text',message)
@@ -157,7 +157,7 @@ class GrowlNotifier:
         #Send Registration
         register = gntp.GNTPRegister()
         register.add_header('Application-Name', opts['app'])
-        register.add_header('Application-Icon', 'https://raw.github.com/midgetspy/Sick-Beard/master/data/images/sickbeard.png')
+        register.add_header('Application-Icon', 'http://www.sickbeard.com/xbmc-notify.png')
         
         register.add_notification('Test', True)
         register.add_notification(common.notifyStrings[common.NOTIFY_SNATCH], True)


### PR DESCRIPTION
The image used for Growl notifications is too wide and gets compressed. I have changed this image to use the image used for XBMC, which is square and doesn't suffer from this issue.
